### PR TITLE
multiple platforms .env support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
  
 ## Installation
 ```sh
-$ wget https://raw.githubusercontent.com/gchaincl/dotenv.sh/master/dotenv.sh -O ~/.dotenv.sh
+$ wget https://raw.githubusercontent.com/digitalist/dotenv.sh/master/dotenv.sh
 ```
 Add the following to your `.bashrc`, `.zshrc` or `.<whatever>rc`:
 ```sh

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ source ~/.dotenv.sh
 
 ## Usage
 Each time you `cd` to a directory, dotenv.sh will try to load a `.env` file and export it's content
+If there are files like `.env.FreeBSD` or `.env.Darwin` or other supported platforms, they will be loaded instead of `.env` file
 
 ## TODO
 * Unload loaded variables when you exit directory

--- a/dotenv.sh
+++ b/dotenv.sh
@@ -7,7 +7,7 @@ case "${unameOut}" in
     Darwin*)    dotenv_machine=Mac;;
     CYGWIN*)    dotenv_machine=Cygwin;;
     MINGW*)     dotenv_machine=MinGw;;
-    *)          dotenv_machine="UNKNOWN:${dotenv_machine_uname}"
+    *)          dotenv_machine="${dotenv_machine_uname}"
 esac
 
 cd()

--- a/dotenv.sh
+++ b/dotenv.sh
@@ -1,8 +1,20 @@
+#!/usr/bin/env 
+
+dotenv_machine_uname="$(uname -s)"
+case "${unameOut}" in
+    Linux*)     dotenv_machine=Linux;;
+    FreeBSD*)   dotenv_machine=FreeBSD;;
+    Darwin*)    dotenv_machine=Mac;;
+    CYGWIN*)    dotenv_machine=Cygwin;;
+    MINGW*)     dotenv_machine=MinGw;;
+    *)          dotenv_machine="UNKNOWN:${dotenv_machine_uname}"
+esac
+
 cd()
 {
 	debug()
 	{
-		if [ $DOTENVSH_DEBUG = true ]; then
+		if [ "$DOTENVSH_DEBUG" = true ]; then
 			echo $1
 		fi
 	}
@@ -18,9 +30,18 @@ cd()
 	builtin cd $@
 	ERR=$?
 
-	if [ $ERR -ne 0 ]; then; return $ERR; fi
+	if [ $ERR -ne 0 ]
+	then
+		return $ERR
+	fi
 
-	if [ -e .env ]; then
-		loadenv .env
+
+
+	if [ -e .env.${dotenv_machine} ]; then
+		loadenv .env.${dotenv_machine}
+	else
+		if [ -e .env ]; then
+			loadenv .env
+		fi
 	fi
 }


### PR DESCRIPTION
I needed to use different .env files on linux and freebsd machine.
This patch enables you to create 
- .env (as default file)
- .env.FreeBSD
- .env.Darwin
- .env.Mac

tested on freebsd and linux